### PR TITLE
Add `TestService`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export declare const StarterPlayer: StarterPlayer;
 export declare const Stats: Stats;
 export declare const Teams: Teams;
 export declare const TeleportService: TeleportService;
+export declare const TestService: TestService;
 export declare const TextChatService: TextChatService;
 export declare const TextService: TextService;
 export declare const TweenService: TweenService;


### PR DESCRIPTION
I saw that this service was removed from there 5 years ago in #5, however, this service is not plugin-only.
Personally, I use this sometimes, mainly for the Message() method to display blue text in the output, which is useful in some scenarios.
Another reason is that even if this would be only for plugin, I suppose developers also use roblox-ts to make plugins. Why shouldn't these be available?